### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-example-action.yml
+++ b/.github/workflows/release-example-action.yml
@@ -1,4 +1,6 @@
 name: Create Example Zip Files on Release
+permissions:
+  contents: write
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/pingidentity/terraform-pingone-utils/security/code-scanning/14](https://github.com/pingidentity/terraform-pingone-utils/security/code-scanning/14)

The best way to fix this issue is to explicitly declare the required minimal permissions for the workflow at the top level, just below the `name:` field and above `on:` in `.github/workflows/release-example-action.yml`. At a minimum, this means adding a `permissions:` block that only grants what the workflow steps need. Because the workflow uses `softprops/action-gh-release@v2` to publish files to a release, it does require write access to repository contents. Therefore, the appropriate permissions to specify are:

```yaml
permissions:
  contents: write
```

This ensures that only the `contents: write` scope is granted (allowing the workflow to create or modify release assets), and all other permissions are denied by default, in line with the principle of least privilege. No code logic or step behavior will change, just the workflow header will be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
