### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/module-checks.yml
+++ b/.github/workflows/module-checks.yml
@@ -1,4 +1,7 @@
 name: Terraform Module Checks
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/pingidentity/terraform-pingone-utils/security/code-scanning/2](https://github.com/pingidentity/terraform-pingone-utils/security/code-scanning/2)

To remedy this, add a `permissions` key at the root level of the workflow file (`.github/workflows/module-checks.yml`), which will set the default permission for all jobs in the workflow. Review of the jobs' steps shows that none of them require write access to the repository or PRs—they only run validations and upload SARIF files. The minimal necessary permission in this case is likely `contents: read` and possibly `security-events: write` (needed for uploading SARIF files via the `upload-sarif` action). Thus, set:

```yaml
permissions:
  contents: read
  security-events: write
```

Insert this directly after the `name:` and before the `on:` block (after line 1), to set the default for the entire workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
